### PR TITLE
Support click event for bar.

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,9 @@
 			on_click: function (task) {
 				console.log(task);
 			},
+			on_dblclick: function (task) {
+				console.log(task);
+			},
 			on_date_change: function(task, start, end) {
 				console.log(task, start, end);
 			},

--- a/src/bar.js
+++ b/src/bar.js
@@ -193,6 +193,15 @@ export default class Bar {
                 return;
             }
 
+            this.gantt.trigger_event('dblclick', [this.task]);
+        });
+
+        $.on(this.group, 'click', (e) => {
+            if (this.action_completed) {
+                // just finished a move action, wait for a few seconds
+                return;
+            }
+
             this.gantt.trigger_event('click', [this.task]);
         });
     }


### PR DESCRIPTION
Click event is supported in the bar. It is needed when you want to determine the selected task in some scenarios. For example, for editing and deleting a task, the selected task is a vital feature.

The double click event is also changed to `on_dblclick` event name